### PR TITLE
Add Windows support.

### DIFF
--- a/tasks/ava.js
+++ b/tasks/ava.js
@@ -7,7 +7,9 @@ module.exports = function (grunt) {
 		var cb = this.async();
 		var args = this.filesSrc.concat('--color');
 
-		childProcess.execFile(BIN, args, function (err, stdout, stderr) {
+		args.unshift(BIN);
+
+		childProcess.execFile('node', args, function (err, stdout, stderr) {
 			if (err) {
 				grunt.warn(stderr);
 				cb();


### PR DESCRIPTION
ava/cli.js makes use of shebang string, which fails on windows.
A solution would be to run cli.js via node. To do so execFile in grunt-ava
calls node and supplies it with args containing cli.js as the first element.

Solution has been successfully tested on windows, mac and linux.
